### PR TITLE
feat: add doc mappings for terramate keywords

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @terramate-io/cli-tooling

--- a/autoload/terramate.vim
+++ b/autoload/terramate.vim
@@ -31,25 +31,33 @@ function! terramate#docs() abort
     if &ft =~ "terramate"
       let s:base_url = "https://terramate.io/docs/cli"
       let s:word = expand("<cword>")
-      if s:word[0:2] == "tm_"
-        let s:type_mapping = {}
-        let s:type_mapping["tm_ternary"] = "functions/terramate-builtin"
-        let s:type_mapping["tm_hcl_expression"] = "functions/terramate-builtin"
-        let s:type_mapping["tm_version_match"] = "functions/terramate-builtin"
-        let s:type_mapping["tm_vendor"] = "functions/terramate-builtin"
 
-        let s:type = get(s:type_mapping, s:word, "functions")
-        let s:url = join([s:base_url, s:type, s:word], "/")
-        if g:os == "Linux"
-          silent exec "!xdg-open '".s:url."'"
-        else
-          silent exec "!open '".s:url."'"
-        endif
-        silent exec "redra!"
-        echo "Documentation: ".s:url
+      let s:type_mapping = {}
+      let s:type_mapping["tm_ternary"] = "functions/terramate-builtin"
+      let s:type_mapping["tm_hcl_expression"] = "functions/terramate-builtin"
+      let s:type_mapping["tm_version_match"] = "functions/terramate-builtin"
+      let s:type_mapping["tm_vendor"] = "functions/terramate-builtin"
+      let s:type_mapping["global"] = "data-sharing/globals"
+      let s:type_mapping["globals"] = "data-sharing/globals"
+      let s:type_mapping["generate_hcl"] = "code-generation/generate-hcl"
+      let s:type_mapping["generate_file"] = "code-generation/generate-file"
+      let s:type_mapping["stack"] = "about-stacks"
+
+      if s:word[0:2] == "tm_"
+        let s:url = join([s:base_url, get(s:type_mapping, s:word, "functions"), s:word], "/")
       else
-        echo "error: only tm_* functions are supported at the moment"
+        let s:url = join([s:base_url, get(s:type_mapping, s:word, "")], "/")
       endif
+
+
+      if g:os == "Linux"
+        silent exec "!xdg-open '".s:url."'"
+      else
+        silent exec "!open '".s:url."'"
+      endif
+      silent exec "redra!"
+      echo "Documentation: ".s:url
+
       return
     else
       return


### PR DESCRIPTION
The following keywords are detected by the plugin and `<leader>tm` would take the user to the relevant documenation page in the browser:

* global/globals
* stack
* generate_file
* generate_hcl

Also added a `CODEOWNERS` file.